### PR TITLE
Add persistent global variable management UI

### DIFF
--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -4,10 +4,15 @@ export type VarName = string;
 export interface VarEntry {
   value: any;
   display: string;
+  source?: string;
 }
 
 export interface NoteScope {
   vars: Map<VarName, VarEntry>;
+}
+
+export interface GlobalVarEntry extends VarEntry {
+  source: string;
 }
 
 export interface ToolkitSettings {
@@ -16,4 +21,9 @@ export interface ToolkitSettings {
   sigFigs: number;
   labNotesFolder: string;
   globalVarsEnabled: boolean;
+}
+
+export interface ToolkitData {
+  settings: ToolkitSettings;
+  globalVars: Record<VarName, GlobalVarEntry>;
 }


### PR DESCRIPTION
## Summary
- add CalcEngine helpers to load, persist, and manage global variables
- persist global constants alongside plugin settings during load/save
- provide a settings panel section to create, update, and delete global constants

## Testing
- npm run build *(fails: esbuild config rejects the `watch` flag in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dec69773a883209bba4034e15d6a40