### PR TITLE
Add diagram command integrations and fix build config

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,25 @@ Open the **Variables Panel** via Command Palette to view current note's variable
 - **Open Variables Panel**
 - **Recalculate current note**
 - **New Experiment Note** (creates a scaffolded lab note under configured folder)
+- **Insert engineering diagram** (choose a diagram plugin integration and insert an embed)
+- **Insert Excalidraw sketch / Diagrams.net drawing / Circuit sketch** (quick commands for specific diagram types)
+
+### Diagram integrations
+
+The diagram helpers rely on the companion community plugins being installed and enabled:
+
+- **Excalidraw** via `obsidian-excalidraw-plugin`
+- **Diagrams.net (Draw.io)** via `drawio-obsidian`
+- **Circuit Sketcher** via `obsidian-circuit-sketcher`
+
+When you run the command, the plugin will prompt for:
+
+1. **Diagram type** (if not using a specific quick command)
+2. **File name**
+3. **Target folder** (defaults per integration; folders are created automatically if needed)
+4. **Template path** (optional; if omitted, a minimal placeholder file is created)
+
+If the related plugin is not available, the command exits with a notice so you can install/enable it before retrying.
 
 ## Settings
 - Auto recalc

--- a/esbuild.config.mjs
+++ b/esbuild.config.mjs
@@ -2,7 +2,7 @@ import esbuild from "esbuild";
 
 const watch = process.argv.includes("--watch");
 
-esbuild.build({
+const buildOptions = {
   entryPoints: ["src/main.ts"],
   outfile: "main.js",
   bundle: true,
@@ -11,13 +11,18 @@ esbuild.build({
   external: ["obsidian"],
   sourcemap: watch ? "inline" : false,
   minify: !watch,
-  logLevel: "info",
-  watch: watch && {
+  logLevel: "info"
+};
+
+if (watch) {
+  buildOptions.watch = {
     onRebuild(err) {
       if (err) console.error("⚠️ Rebuild failed:", err);
       else console.log("✅ Rebuilt");
     }
-  }
-}).then(() => {
+  };
+}
+
+esbuild.build(buildOptions).then(() => {
   console.log(watch ? "👀 Watching…" : "✅ Built");
 });

--- a/src/labJournal.ts
+++ b/src/labJournal.ts
@@ -8,43 +8,44 @@ export async function createExperimentNote(plugin: EngineeringToolkitPlugin) {
   const dateStr = (app as any).moment().format("YYYY-MM-DD");
   const folder = plugin.settings.labNotesFolder || "Lab Journal";
   const safeTitle = title.replace(/[\\/:*?"<>|]/g, "-");
-  const fileName = `${dateStr} ${safeTitle}.md";
+  const fileName = `${dateStr} ${safeTitle}.md`;
   const path = `${folder}/${fileName}`;
 
-  const content = `---
-experiment_id: ${dateStr}-${safeTitle.replace(/\s+/g,"-")}
-date: ${dateStr}
-tags: lab
----
-
-# ${title}
-
-**Date:** ${dateStr}  
-**Researchers:** 
-
-## Objective
-- 
-
-## Procedure
-1. 
-
-## Data & Calculations
-\\`\\`\\`calc
-# Define inputs
-mass = 5 kg
-accel = 9.81 m/s^2
-force = mass * accel
-
-# Convert example
-force -> lbf
-\\`\\`\\`
-
-## Results
-- 
-
-## Conclusion
-- 
-`;
+  const content = [
+    "---",
+    `experiment_id: ${dateStr}-${safeTitle.replace(/\s+/g, "-")}`,
+    `date: ${dateStr}`,
+    "tags: lab",
+    "---",
+    "",
+    `# ${title}`,
+    "",
+    `**Date:** ${dateStr}`,
+    "**Researchers:**",
+    "",
+    "## Objective",
+    "-",
+    "",
+    "## Procedure",
+    "1.",
+    "",
+    "## Data & Calculations",
+    "```calc",
+    "# Define inputs",
+    "mass = 5 kg",
+    "accel = 9.81 m/s^2",
+    "force = mass * accel",
+    "",
+    "# Convert example",
+    "force -> lbf",
+    "```",
+    "",
+    "## Results",
+    "-",
+    "",
+    "## Conclusion",
+    "-"
+  ].join("\n");
 
   if (!app.vault.getAbstractFileByPath(folder)) {
     await app.vault.createFolder(folder).catch(() => {});

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,4 +1,4 @@
-import { Plugin, MarkdownPostProcessorContext, WorkspaceLeaf } from "obsidian";
+import { Plugin, MarkdownPostProcessorContext, WorkspaceLeaf, Notice, MarkdownView, SuggestModal, TFile, normalizePath } from "obsidian";
 import { DEFAULT_SETTINGS, ToolkitSettingTab } from "./settings";
 import type { ToolkitSettings, NoteScope } from "./utils/types";
 import { CalcEngine } from "./calcEngine";
@@ -10,6 +10,41 @@ export default class EngineeringToolkitPlugin extends Plugin {
   private calc: CalcEngine;
   private varsLeaf: WorkspaceLeaf | null = null;
   private currentScope: NoteScope | null = null;
+
+  private diagramIntegrations: DiagramIntegration[] = [
+    {
+      key: "excalidraw",
+      name: "Excalidraw sketch",
+      description: "Creates a new Excalidraw canvas and embeds it in the note.",
+      pluginId: "obsidian-excalidraw-plugin",
+      fileExtension: ".excalidraw.md",
+      defaultFolder: "Excalidraw",
+      defaultFrontmatter: "---\nexcalidraw-plugin: parsed\n---\n",
+      embedPrefix: "![[",
+      embedSuffix: "]]"
+    },
+    {
+      key: "drawio",
+      name: "Diagrams.net drawing",
+      description: "Creates a Diagrams.net file placeholder for the Draw.io plugin.",
+      pluginId: "drawio-obsidian",
+      fileExtension: ".drawio",
+      defaultFolder: "Diagrams",
+      embedPrefix: "![[",
+      embedSuffix: "]]"
+    },
+    {
+      key: "circuit",
+      name: "Circuit sketch",
+      description: "Prepares a Circuit Sketcher canvas and embeds it in the current note.",
+      pluginId: "obsidian-circuit-sketcher",
+      fileExtension: ".circuit.md",
+      defaultFolder: "Circuits",
+      defaultFrontmatter: "---\nplugin: circuit-sketcher\n---\n",
+      embedPrefix: "![[",
+      embedSuffix: "]]"
+    }
+  ];
 
   async onload() {
     console.log("Loading Engineering Toolkit");
@@ -46,6 +81,20 @@ export default class EngineeringToolkitPlugin extends Plugin {
       name: "New Experiment Note",
       callback: async () => { await createExperimentNote(this); }
     });
+
+    this.addCommand({
+      id: "insert-diagram-placeholder",
+      name: "Insert engineering diagram",
+      callback: async () => { await this.insertDiagramFlow(); }
+    });
+
+    for (const integration of this.diagramIntegrations) {
+      this.addCommand({
+        id: `insert-diagram-${integration.key}`,
+        name: `Insert ${integration.name}`,
+        callback: async () => { await this.insertDiagramFlow(integration.key); }
+      });
+    }
 
     this.registerEvent(this.app.workspace.on("file-open", async (f) => {
       if (!f) return;
@@ -102,4 +151,129 @@ export default class EngineeringToolkitPlugin extends Plugin {
       modal.open();
     });
   }
+
+  private async insertDiagramFlow(preselectedKey?: string) {
+    const editor = this.app.workspace.getActiveViewOfType(MarkdownView)?.editor;
+    if (!editor) {
+      new Notice("Open a Markdown note before inserting a diagram placeholder.");
+      return;
+    }
+
+    const integration = preselectedKey
+      ? this.diagramIntegrations.find(d => d.key === preselectedKey)
+      : await this.selectDiagramIntegration();
+
+    if (!integration) return;
+
+    if (!this.isPluginAvailable(integration.pluginId)) {
+      new Notice(`${integration.name} requires the companion plugin (${integration.pluginId}) to be enabled.`);
+      return;
+    }
+
+    const baseName = await this.prompt(`Enter file name for the ${integration.name}:`);
+    if (!baseName) return;
+
+    const folderInput = await this.prompt(`Target folder (default: ${integration.defaultFolder}):`);
+    const targetFolder = folderInput?.trim() || integration.defaultFolder;
+
+    const templatePath = await this.prompt("Template path (optional, leave blank to use default placeholder):");
+    let filePath: string;
+    try {
+      filePath = await this.createDiagramFile(integration, baseName.trim(), targetFolder, templatePath?.trim() || null);
+    } catch (error: any) {
+      new Notice(error?.message || "Failed to prepare diagram file.");
+      return;
+    }
+
+    const embed = `${integration.embedPrefix || "![["}${filePath}${integration.embedSuffix || "]]"}`;
+    editor.replaceSelection(embed);
+  }
+
+  private async selectDiagramIntegration(): Promise<DiagramIntegration | null> {
+    if (this.diagramIntegrations.length === 1) return this.diagramIntegrations[0];
+    return new Promise(resolve => {
+      const modal = new (class extends SuggestModal<DiagramIntegration> {
+        private resolved = false;
+        constructor(private readonly plugin: EngineeringToolkitPlugin) {
+          super(plugin.app);
+        }
+        getSuggestions(query: string): DiagramIntegration[] {
+          const lower = query.toLowerCase();
+          return this.plugin.diagramIntegrations.filter(d =>
+            !query || d.name.toLowerCase().includes(lower) || d.key.toLowerCase().includes(lower)
+          );
+        }
+        renderSuggestion(value: DiagramIntegration, el: HTMLElement) {
+          el.createEl("div", { text: value.name });
+          if (value.description) {
+            el.createEl("small", { text: value.description });
+          }
+        }
+        onChooseSuggestion(item: DiagramIntegration) {
+          this.resolved = true;
+          resolve(item);
+        }
+        onClose() {
+          if (!this.resolved) resolve(null);
+        }
+      })(this);
+      modal.setPlaceholder("Select diagram type");
+      modal.open();
+    });
+  }
+
+  private isPluginAvailable(id: string): boolean {
+    const pluginsApi = (this.app as any).plugins;
+    if (!pluginsApi) return false;
+    if (pluginsApi.enabledPlugins instanceof Set) {
+      return pluginsApi.enabledPlugins.has(id);
+    }
+    return Boolean(pluginsApi.plugins?.[id]);
+  }
+
+  private async createDiagramFile(
+    integration: DiagramIntegration,
+    baseName: string,
+    targetFolder: string,
+    templatePath: string | null
+  ): Promise<string> {
+    const vault = this.app.vault;
+    const folder = normalizePath(targetFolder || ".");
+    if (folder !== "." && !vault.getAbstractFileByPath(folder)) {
+      await vault.createFolder(folder).catch(() => {});
+    }
+
+    const extension = integration.fileExtension.startsWith(".") ? integration.fileExtension : `.${integration.fileExtension}`;
+    const sanitizedName = baseName.replace(/[\\/:*?"<>|]/g, "-");
+    const path = normalizePath(folder === "." ? `${sanitizedName}${extension}` : `${folder}/${sanitizedName}${extension}`);
+
+    if (vault.getAbstractFileByPath(path)) {
+      throw new Error("A diagram with that name already exists.");
+    }
+
+    let contents = integration.defaultFrontmatter ?? "";
+    if (templatePath) {
+      const normalizedTemplate = normalizePath(templatePath);
+      const templateFile = vault.getAbstractFileByPath(normalizedTemplate);
+      if (!(templateFile instanceof TFile)) {
+        throw new Error("Template file was not found.");
+      }
+      contents = await vault.read(templateFile);
+    }
+
+    await vault.create(path, contents);
+    return path;
+  }
+}
+
+interface DiagramIntegration {
+  key: string;
+  name: string;
+  description?: string;
+  pluginId: string;
+  fileExtension: string;
+  defaultFolder: string;
+  defaultFrontmatter?: string;
+  embedPrefix?: string;
+  embedSuffix?: string;
 }


### PR DESCRIPTION
## Summary
- add engineering diagram commands that prompt for diagram type, target folder, and optional templates while ensuring companion plugins are enabled
- document diagram integrations and their dependencies in the README
- clean up the esbuild configuration and lab journal template so builds succeed

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dec6b07cb88320910ee17dc03b7e98