### PR TITLE
Add Model Viewer embed command and settings

### DIFF
--- a/src/settings.ts
+++ b/src/settings.ts
@@ -7,7 +7,15 @@ export const DEFAULT_SETTINGS: ToolkitSettings = {
   defaultUnitSystem: "SI",
   sigFigs: 4,
   labNotesFolder: "Lab Journal",
-  globalVarsEnabled: false
+  globalVarsEnabled: false,
+  modelViewerDefaults: {
+    altText: "3D model",
+    cameraControls: true,
+    autoRotate: false,
+    backgroundColor: "#ffffff",
+    environmentImage: "",
+    exposure: "1"
+  }
 };
 
 export class ToolkitSettingTab extends PluginSettingTab {
@@ -21,6 +29,7 @@ export class ToolkitSettingTab extends PluginSettingTab {
   display(): void {
     const { containerEl } = this;
     containerEl.empty();
+    this.plugin.refreshModelViewerAvailability();
     containerEl.createEl("h2", { text: "Engineering Toolkit Settings" });
 
     new Setting(containerEl)
@@ -55,5 +64,79 @@ export class ToolkitSettingTab extends PluginSettingTab {
       .setDesc("Make variables available across notes (experimental)")
       .addToggle(t => t.setValue(this.plugin.settings.globalVarsEnabled)
         .onChange(async v => { this.plugin.settings.globalVarsEnabled = v; await this.plugin.saveSettings(); }));
+
+    new Setting(containerEl)
+      .setName("Model Viewer")
+      .setHeading();
+
+    new Setting(containerEl)
+      .setName("Dependency status")
+      .setDesc(this.plugin.modelViewerAvailable
+        ? "Model Viewer plugin detected. Inserted embeds will render in preview."
+        : "Model Viewer plugin not detected. Install and enable the community Model Viewer plugin to render embeds.");
+
+    new Setting(containerEl)
+      .setName("Default alt text")
+      .setDesc("Alt text applied to inserted <model-viewer> elements.")
+      .addText(t => t
+        .setPlaceholder("3D model")
+        .setValue(this.plugin.settings.modelViewerDefaults.altText)
+        .onChange(async v => {
+          this.plugin.settings.modelViewerDefaults.altText = v;
+          await this.plugin.saveSettings();
+        }));
+
+    new Setting(containerEl)
+      .setName("Camera controls")
+      .setDesc("Enable orbit controls by default.")
+      .addToggle(t => t
+        .setValue(this.plugin.settings.modelViewerDefaults.cameraControls)
+        .onChange(async v => {
+          this.plugin.settings.modelViewerDefaults.cameraControls = v;
+          await this.plugin.saveSettings();
+        }));
+
+    new Setting(containerEl)
+      .setName("Auto rotate")
+      .setDesc("Automatically rotate models when inserted embeds load.")
+      .addToggle(t => t
+        .setValue(this.plugin.settings.modelViewerDefaults.autoRotate)
+        .onChange(async v => {
+          this.plugin.settings.modelViewerDefaults.autoRotate = v;
+          await this.plugin.saveSettings();
+        }));
+
+    new Setting(containerEl)
+      .setName("Background color")
+      .setDesc("CSS color applied to the viewer background (leave blank for default).")
+      .addText(t => t
+        .setPlaceholder("#ffffff")
+        .setValue(this.plugin.settings.modelViewerDefaults.backgroundColor)
+        .onChange(async v => {
+          this.plugin.settings.modelViewerDefaults.backgroundColor = v;
+          await this.plugin.saveSettings();
+        }));
+
+    new Setting(containerEl)
+      .setName("Environment image")
+      .setDesc("Default environment-image attribute value (optional).")
+      .addText(t => t
+        .setPlaceholder("URL or vault path")
+        .setValue(this.plugin.settings.modelViewerDefaults.environmentImage)
+        .onChange(async v => {
+          this.plugin.settings.modelViewerDefaults.environmentImage = v;
+          await this.plugin.saveSettings();
+        }));
+
+    new Setting(containerEl)
+      .setName("Exposure")
+      .setDesc("Default exposure attribute (leave blank to omit).")
+      .addText(t => t
+        .setPlaceholder("1")
+        .setValue(this.plugin.settings.modelViewerDefaults.exposure)
+        .onChange(async v => {
+          this.plugin.settings.modelViewerDefaults.exposure = v;
+          await this.plugin.saveSettings();
+        }));
   }
 }

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -10,10 +10,20 @@ export interface NoteScope {
   vars: Map<VarName, VarEntry>;
 }
 
+export interface ModelViewerDefaults {
+  altText: string;
+  cameraControls: boolean;
+  autoRotate: boolean;
+  backgroundColor: string;
+  environmentImage: string;
+  exposure: string;
+}
+
 export interface ToolkitSettings {
   autoRecalc: boolean;
   defaultUnitSystem: "SI" | "US";
   sigFigs: number;
   labNotesFolder: string;
   globalVarsEnabled: boolean;
+  modelViewerDefaults: ModelViewerDefaults;
 }


### PR DESCRIPTION
## Summary
- register a command that prompts for a model resource and inserts a `<model-viewer>` embed using saved defaults
- extend the settings tab with Model Viewer defaults and dependency status messaging
- detect the external Model Viewer plugin and surface notices when it is unavailable

## Testing
- `npm run build` *(fails: esbuild config still passes the deprecated watch option to the current esbuild version)*

------
https://chatgpt.com/codex/tasks/task_e_68dec6b751c0832091ab8c34752155ac