### PR TITLE
Add lab index settings and update experiment note creation

### DIFF
--- a/src/labJournal.ts
+++ b/src/labJournal.ts
@@ -8,7 +8,7 @@ export async function createExperimentNote(plugin: EngineeringToolkitPlugin) {
   const dateStr = (app as any).moment().format("YYYY-MM-DD");
   const folder = plugin.settings.labNotesFolder || "Lab Journal";
   const safeTitle = title.replace(/[\\/:*?"<>|]/g, "-");
-  const fileName = `${dateStr} ${safeTitle}.md";
+  const fileName = `${dateStr} ${safeTitle}.md`;
   const path = `${folder}/${fileName}`;
 
   const content = `---
@@ -29,7 +29,7 @@ tags: lab
 1. 
 
 ## Data & Calculations
-\\`\\`\\`calc
+\`\`\`calc
 # Define inputs
 mass = 5 kg
 accel = 9.81 m/s^2
@@ -37,7 +37,7 @@ force = mass * accel
 
 # Convert example
 force -> lbf
-\\`\\`\\`
+\`\`\`
 
 ## Results
 - 
@@ -50,11 +50,57 @@ force -> lbf
     await app.vault.createFolder(folder).catch(() => {});
   }
 
+  const existing = app.vault.getAbstractFileByPath(path);
+  if (existing instanceof TFile) {
+    new Notice("Experiment note already exists. Opening existing note.");
+    await app.workspace.getLeaf(true).openFile(existing);
+    await updateLabIndex(plugin, title, path, dateStr);
+    return;
+  }
+
   try {
     await app.vault.create(path, content);
     const f = app.vault.getAbstractFileByPath(path);
-    if (f instanceof TFile) await app.workspace.getLeaf(true).openFile(f);
+    if (f instanceof TFile) {
+      await app.workspace.getLeaf(true).openFile(f);
+      await updateLabIndex(plugin, title, path, dateStr);
+    }
   } catch (e) {
-    new Notice("Failed to create experiment note (maybe exists?)");
+    console.error("Failed to create experiment note", e);
+    new Notice("Failed to create experiment note");
+  }
+}
+
+async function updateLabIndex(plugin: EngineeringToolkitPlugin, title: string, path: string, dateStr: string) {
+  const app = plugin.app;
+  const indexSetting = plugin.settings.labIndexPath?.trim();
+  if (!indexSetting) return;
+
+  const normalizedPath = indexSetting.endsWith(".md")
+    ? indexSetting
+    : `${indexSetting.replace(/\/$/, "") || "Lab Journal"}/index.md`;
+
+  const indexFolder = normalizedPath.split("/").slice(0, -1).join("/");
+  if (indexFolder && !app.vault.getAbstractFileByPath(indexFolder)) {
+    await app.vault.createFolder(indexFolder).catch(() => {});
+  }
+
+  try {
+    const indexFile = app.vault.getAbstractFileByPath(normalizedPath);
+    const linkTarget = path.replace(/\.md$/, "");
+    const entryLine = `- ${dateStr} [[${linkTarget}|${title}]]`;
+
+    if (indexFile instanceof TFile) {
+      const current = await app.vault.read(indexFile);
+      if (current.includes(linkTarget)) return;
+      const updated = `${current.trimEnd()}\n${entryLine}\n`;
+      await app.vault.modify(indexFile, updated);
+    } else {
+      const initial = `# Lab Journal Index\n\n${entryLine}\n`;
+      await app.vault.create(normalizedPath, initial);
+    }
+  } catch (err) {
+    console.error("Failed to update lab index", err);
+    new Notice("Failed to update lab index");
   }
 }

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -7,6 +7,7 @@ export const DEFAULT_SETTINGS: ToolkitSettings = {
   defaultUnitSystem: "SI",
   sigFigs: 4,
   labNotesFolder: "Lab Journal",
+  labIndexPath: "Lab Journal/index.md",
   globalVarsEnabled: false
 };
 
@@ -49,6 +50,16 @@ export class ToolkitSettingTab extends PluginSettingTab {
       .addText(t => t.setPlaceholder("Lab Journal")
         .setValue(this.plugin.settings.labNotesFolder)
         .onChange(async v => { this.plugin.settings.labNotesFolder = v || "Lab Journal"; await this.plugin.saveSettings(); }));
+
+    new Setting(containerEl)
+      .setName("Lab index")
+      .setDesc("Path to an index note or folder for experiment listings")
+      .addText(t => t.setPlaceholder("Lab Journal/index.md")
+        .setValue(this.plugin.settings.labIndexPath)
+        .onChange(async v => {
+          this.plugin.settings.labIndexPath = v?.trim() || "";
+          await this.plugin.saveSettings();
+        }));
 
     new Setting(containerEl)
       .setName("Global variables")

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -15,5 +15,6 @@ export interface ToolkitSettings {
   defaultUnitSystem: "SI" | "US";
   sigFigs: number;
   labNotesFolder: string;
+  labIndexPath: string;
   globalVarsEnabled: boolean;
 }


### PR DESCRIPTION
## Summary
- add a setting to capture the desired lab index path alongside existing lab journal options
- update experiment note creation to avoid duplicates and append new entries to the configured index

## Testing
- npm run build *(fails: esbuild config rejects the deprecated `watch` option even when unused)*
- npx tsc --noEmit *(fails: existing strict property initialization errors in main.ts and variablesView.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68dec6ce37a48320ade504b1a833a2ba