### PR TITLE
Add scope-aware autocomplete for calc blocks

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "typescript": "^5.5.4"
   },
   "dependencies": {
+    "@codemirror/autocomplete": "^6.19.0",
     "mathjs": "^13.0.1"
   }
 }

--- a/src/autocomplete.ts
+++ b/src/autocomplete.ts
@@ -1,0 +1,101 @@
+import { autocompletion, closeCompletion, Completion, CompletionContext, CompletionResult, completionStatus, startCompletion } from "@codemirror/autocomplete";
+import { StateEffect, StateField, Extension } from "@codemirror/state";
+import { editorInfoField } from "obsidian";
+import type EngineeringToolkitPlugin from "./main";
+
+const scopeRefreshEffect = StateEffect.define<number>();
+
+const scopeRefreshField = StateField.define<number>({
+  create: () => 0,
+  update(value, tr) {
+    for (const effect of tr.effects) {
+      if (effect.is(scopeRefreshEffect)) return effect.value;
+    }
+    return value;
+  }
+});
+
+export class ScopeCompletionManager {
+  private plugin: EngineeringToolkitPlugin;
+  readonly extension: Extension;
+
+  constructor(plugin: EngineeringToolkitPlugin) {
+    this.plugin = plugin;
+    this.extension = [
+      scopeRefreshField,
+      autocompletion({
+        override: [ctx => this.provideCompletions(ctx)],
+        activateOnTyping: true
+      })
+    ];
+  }
+
+  notifyChanged() {
+    const stamp = Date.now();
+    this.plugin.app.workspace.iterateAllLeaves(leaf => {
+      const cm = (leaf.view as any)?.editor?.cm;
+      if (!cm) return;
+      cm.dispatch({ effects: scopeRefreshEffect.of(stamp) });
+      if (completionStatus(cm.state)) startCompletion(cm);
+    });
+  }
+
+  updateEnabledState() {
+    const enabled = this.plugin.settings.autocompleteEnabled;
+    this.plugin.app.workspace.iterateAllLeaves(leaf => {
+      const cm = (leaf.view as any)?.editor?.cm;
+      if (!cm) return;
+      if (!enabled) {
+        closeCompletion(cm);
+      } else if (completionStatus(cm.state)) {
+        startCompletion(cm);
+      }
+    });
+  }
+
+  private provideCompletions(context: CompletionContext): CompletionResult | null {
+    // Mark dependency so refresh effect retriggers completion source.
+    context.state.field(scopeRefreshField);
+
+    if (!this.plugin.settings.autocompleteEnabled) return null;
+    if (!this.isInCalcBlock(context)) return null;
+
+    const word = context.matchBefore(/[A-Za-z_][A-Za-z0-9_]*/);
+    if (!word && !context.explicit) return null;
+
+    const fileInfo = context.state.field(editorInfoField, false);
+    const filePath = fileInfo?.file?.path ?? null;
+    const options = this.plugin.getScopeCompletions(filePath);
+    if (!options.length) return null;
+
+    if (!word) {
+      return { from: context.pos, options };
+    }
+
+    const query = word.text.toLowerCase();
+    const filtered = options.filter(opt => opt.label.toLowerCase().startsWith(query));
+    return {
+      from: word.from,
+      options: filtered.length ? filtered : options
+    };
+  }
+
+  private isInCalcBlock(context: CompletionContext): boolean {
+    const doc = context.state.doc;
+    const targetLine = doc.lineAt(context.pos).number;
+    let inCalc = false;
+    for (let lineNum = 1; lineNum <= targetLine; lineNum++) {
+      const text = doc.line(lineNum).text.trim();
+      if (!text.startsWith("```") && !text.startsWith("~~~")) continue;
+      const fence = text.slice(3).trim().toLowerCase();
+      if (!inCalc) {
+        inCalc = fence === "calc";
+      } else {
+        inCalc = false;
+      }
+    }
+    return inCalc;
+  }
+}
+
+export type ScopeCompletionOption = Completion;

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -7,7 +7,8 @@ export const DEFAULT_SETTINGS: ToolkitSettings = {
   defaultUnitSystem: "SI",
   sigFigs: 4,
   labNotesFolder: "Lab Journal",
-  globalVarsEnabled: false
+  globalVarsEnabled: false,
+  autocompleteEnabled: true
 };
 
 export class ToolkitSettingTab extends PluginSettingTab {
@@ -55,5 +56,15 @@ export class ToolkitSettingTab extends PluginSettingTab {
       .setDesc("Make variables available across notes (experimental)")
       .addToggle(t => t.setValue(this.plugin.settings.globalVarsEnabled)
         .onChange(async v => { this.plugin.settings.globalVarsEnabled = v; await this.plugin.saveSettings(); }));
+
+    new Setting(containerEl)
+      .setName("Calc block autocomplete")
+      .setDesc("Suggest scope variables and units while editing calc blocks")
+      .addToggle(t => t.setValue(this.plugin.settings.autocompleteEnabled)
+        .onChange(async v => {
+          this.plugin.settings.autocompleteEnabled = v;
+          await this.plugin.saveSettings();
+          this.plugin.updateAutocompleteSetting();
+        }));
   }
 }

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -16,4 +16,5 @@ export interface ToolkitSettings {
   sigFigs: number;
   labNotesFolder: string;
   globalVarsEnabled: boolean;
+  autocompleteEnabled: boolean;
 }


### PR DESCRIPTION
## Summary
- introduce a CodeMirror completion manager that offers calc block suggestions from the current scope and known units
- refresh editor completions when the CalcEngine updates scopes and when autocomplete is toggled
- add a plugin setting to enable or disable calc block autocomplete and expose the new configuration field

## Testing
- npm run build *(fails: esbuild config rejects the legacy `watch` option in this repo)*
- npx tsc --noEmit *(fails: pre-existing syntax issues in `src/labJournal.ts`)*

------
https://chatgpt.com/codex/tasks/task_e_68dec71a381c832094c5a59a67459cde