### PR TITLE
Preserve manual scope in manual mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,11 +29,16 @@ Open the **Variables Panel** via Command Palette to view current note's variable
 ## Commands
 - **Open Variables Panel**
 - **Recalculate current note**
+- **Reset current note scope**
 - **New Experiment Note** (creates a scaffolded lab note under configured folder)
 
 ## Settings
-- Auto recalc
+- Auto recalc (disable for manual mode; existing variables persist until you reset the scope)
 - Default unit system (display preference)
 - Significant figures
 - Lab notes folder
 - Global variables (experimental)
+
+### Manual mode
+When **Auto recalc** is turned off, the plugin leaves previously calculated variables in place so you can selectively re-run calculations without losing context.
+Use the **Reset current note scope** command whenever you want to clear the stored variables for a note and start fresh.

--- a/src/calcEngine.ts
+++ b/src/calcEngine.ts
@@ -15,13 +15,13 @@ export class CalcEngine {
     return this.scopes.get(filePath)!;
   }
   clearScope(filePath: string) { this.scopes.delete(filePath); }
+  clearAllScopes() { this.scopes.clear(); }
 
   async evaluateBlock(source: string, ctx: MarkdownPostProcessorContext): Promise<HTMLElement> {
     const container = document.createElement("div");
     container.classList.add("calc-output");
 
     const filePath = ctx.sourcePath || "untitled";
-    if (!this.plugin.settings.autoRecalc) this.clearScope(filePath);
     const scope = this.getScope(filePath);
 
     const lines = source.split(/\r?\n/);

--- a/src/main.ts
+++ b/src/main.ts
@@ -42,6 +42,18 @@ export default class EngineeringToolkitPlugin extends Plugin {
     });
 
     this.addCommand({
+      id: "reset-current-scope",
+      name: "Reset current note scope",
+      callback: () => {
+        const file = this.app.workspace.getActiveFile();
+        if (!file) return;
+        this.calc.clearScope(file.path);
+        this.currentScope = null;
+        this.refreshVariablesView(null);
+      }
+    });
+
+    this.addCommand({
       id: "new-experiment-note",
       name: "New Experiment Note",
       callback: async () => { await createExperimentNote(this); }


### PR DESCRIPTION
## Summary
- keep calc scopes intact when automatic recalculation is disabled so manual mode retains variables
- add a command to reset the active note's calculation scope and expose a utility to clear all scopes
- document the new manual mode behaviour and reset command in the README

## Testing
- `npm run build` *(fails: esbuild config rejects the watch option in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dec73f41a88320a4b97f8af9bb7b60